### PR TITLE
feat: 일자리 지원, 거절 api 작성

### DIFF
--- a/src/main/java/com/becareful/becarefulserver/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/recruitment/controller/RecruitmentController.java
@@ -3,6 +3,7 @@ package com.becareful.becarefulserver.domain.recruitment.controller;
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -54,6 +55,13 @@ public class RecruitmentController {
     @PostMapping("/{recruitmentId}/apply")
     public ResponseEntity<Void> applyRecruitment(@PathVariable("recruitmentId") Long recruitmentId) {
         recruitmentService.applyRecruitment(recruitmentId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "매칭 공고 거절 (요양보호사 일자리 거절)")
+    @PostMapping("/{recruitmentId}/reject")
+    public ResponseEntity<Void> rejectMatching(@PathVariable("recruitmentId") Long recruitmentId) {
+        recruitmentService.rejectMatching(recruitmentId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/becareful/becarefulserver/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/recruitment/controller/RecruitmentController.java
@@ -49,4 +49,11 @@ public class RecruitmentController {
         RecruitmentDetailResponse response = recruitmentService.getRecruitmentDetail(recruitmentId);
         return ResponseEntity.ok(response);
     }
+
+    @Operation(summary = "매칭 공고 지원 (요양보호사 일자리 지원)")
+    @PostMapping("/{recruitmentId}/apply")
+    public ResponseEntity<Void> applyRecruitment(@PathVariable("recruitmentId") Long recruitmentId) {
+        recruitmentService.applyRecruitment(recruitmentId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/becareful/becarefulserver/domain/recruitment/domain/Matching.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/recruitment/domain/Matching.java
@@ -14,6 +14,7 @@ import jakarta.persistence.ManyToOne;
 import com.becareful.becarefulserver.domain.caregiver.domain.WorkApplication;
 import com.becareful.becarefulserver.domain.common.domain.BaseEntity;
 
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,6 +32,8 @@ public class Matching extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private MatchingStatus matchingStatus;
+
+    private LocalDate applicationDate;
 
     @JoinColumn(name = "recruitment_id")
     @ManyToOne(fetch = FetchType.LAZY)
@@ -54,5 +57,14 @@ public class Matching extends BaseEntity {
                 .recruitment(recruitment)
                 .workApplication(application)
                 .build();
+    }
+
+    /**
+     * Entity Method
+     */
+
+    public void apply() {
+        this.matchingStatus = MatchingStatus.지원;
+        this.applicationDate = LocalDate.now();
     }
 }

--- a/src/main/java/com/becareful/becarefulserver/domain/recruitment/domain/Matching.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/recruitment/domain/Matching.java
@@ -1,5 +1,8 @@
 package com.becareful.becarefulserver.domain.recruitment.domain;
 
+import static com.becareful.becarefulserver.global.exception.ErrorMessage.MATCHING_CANNOT_APPLY;
+import static com.becareful.becarefulserver.global.exception.ErrorMessage.MATCHING_CANNOT_REJECT;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -13,6 +16,7 @@ import jakarta.persistence.ManyToOne;
 
 import com.becareful.becarefulserver.domain.caregiver.domain.WorkApplication;
 import com.becareful.becarefulserver.domain.common.domain.BaseEntity;
+import com.becareful.becarefulserver.global.exception.exception.RecruitmentException;
 
 import java.time.LocalDate;
 import lombok.AccessLevel;
@@ -64,7 +68,17 @@ public class Matching extends BaseEntity {
      */
 
     public void apply() {
+        if (!this.matchingStatus.equals(MatchingStatus.미지원)) {
+            throw new RecruitmentException(MATCHING_CANNOT_APPLY);
+        }
         this.matchingStatus = MatchingStatus.지원;
         this.applicationDate = LocalDate.now();
+    }
+
+    public void reject() {
+        if (!this.matchingStatus.equals(MatchingStatus.미지원)) {
+            throw new RecruitmentException(MATCHING_CANNOT_REJECT);
+        }
+        this.matchingStatus = MatchingStatus.거절;
     }
 }

--- a/src/main/java/com/becareful/becarefulserver/domain/recruitment/domain/MatchingStatus.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/recruitment/domain/MatchingStatus.java
@@ -1,5 +1,5 @@
 package com.becareful.becarefulserver.domain.recruitment.domain;
 
 public enum MatchingStatus {
-    미지원, 지원, 합격, 거절
+    미지원, 지원, 합격, 거절, 불합격
 }

--- a/src/main/java/com/becareful/becarefulserver/domain/recruitment/repository/MatchingRepository.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/recruitment/repository/MatchingRepository.java
@@ -14,7 +14,8 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
 
     @Query("SELECT m.recruitment "
             + "FROM Matching m "
-            + "WHERE m.workApplication = :workApplication")
+            + "WHERE m.workApplication = :workApplication "
+            + "AND m.matchingStatus = '미지원'")
     List<Recruitment> findAllRecruitmentByWorkApplication(WorkApplication workApplication);
 
     Optional<Matching> findByWorkApplicationAndRecruitment(WorkApplication workApplication, Recruitment recruitment);

--- a/src/main/java/com/becareful/becarefulserver/domain/recruitment/repository/MatchingRepository.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/recruitment/repository/MatchingRepository.java
@@ -8,6 +8,7 @@ import com.becareful.becarefulserver.domain.recruitment.domain.Matching;
 import com.becareful.becarefulserver.domain.recruitment.domain.Recruitment;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MatchingRepository extends JpaRepository<Matching, Long> {
 
@@ -15,4 +16,6 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
             + "FROM Matching m "
             + "WHERE m.workApplication = :workApplication")
     List<Recruitment> findAllRecruitmentByWorkApplication(WorkApplication workApplication);
+
+    Optional<Matching> findByWorkApplicationAndRecruitment(WorkApplication workApplication, Recruitment recruitment);
 }

--- a/src/main/java/com/becareful/becarefulserver/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/recruitment/service/RecruitmentService.java
@@ -42,13 +42,10 @@ public class RecruitmentService {
 
     public List<RecruitmentResponse> getRecruitmentList() {
         Caregiver caregiver = authUtil.getLoggedInCaregiver();
-        WorkApplication workApplication = workApplicationRepository.findByCaregiver(caregiver)
-                .orElseThrow(() -> new RecruitmentException(CAREGIVER_WORK_APPLICATION_NOT_EXISTS));
-
-        // TODO : 일자리 신청서가 비활성화 된 경우 처리 로직 문의
-
-        return matchingRepository.findAllRecruitmentByWorkApplication(workApplication)
-                .stream().map(RecruitmentResponse::from).toList();
+        return workApplicationRepository.findByCaregiver(caregiver)
+                .map(workApplication -> matchingRepository.findAllRecruitmentByWorkApplication(workApplication)
+                        .stream().map(RecruitmentResponse::from).toList())
+                .orElse(null);
     }
 
     public RecruitmentDetailResponse getRecruitmentDetail(Long recruitmentId) {

--- a/src/main/java/com/becareful/becarefulserver/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/recruitment/service/RecruitmentService.java
@@ -61,6 +61,20 @@ public class RecruitmentService {
     }
 
     @Transactional
+    public void rejectMatching(Long recruitmentId) {
+        Caregiver caregiver = authUtil.getLoggedInCaregiver();
+        Recruitment recruitment = recruitmentRepository.findById(recruitmentId)
+                .orElseThrow(() -> new RecruitmentException(RECRUITMENT_NOT_EXISTS));
+        WorkApplication workApplication = workApplicationRepository.findByCaregiver(caregiver)
+                .orElseThrow(() -> new RecruitmentException(CAREGIVER_WORK_APPLICATION_NOT_EXISTS));
+
+        Matching matching = matchingRepository.findByWorkApplicationAndRecruitment(workApplication, recruitment)
+                .orElseThrow(() -> new RecruitmentException(MATCHING_NOT_EXISTS));
+
+        matching.reject();
+    }
+
+    @Transactional
     public void applyRecruitment(Long recruitmentId) {
         Caregiver caregiver = authUtil.getLoggedInCaregiver();
         Recruitment recruitment = recruitmentRepository.findById(recruitmentId)

--- a/src/main/java/com/becareful/becarefulserver/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/recruitment/service/RecruitmentService.java
@@ -2,6 +2,7 @@ package com.becareful.becarefulserver.domain.recruitment.service;
 
 import static com.becareful.becarefulserver.global.exception.ErrorMessage.CAREGIVER_WORK_APPLICATION_NOT_EXISTS;
 import static com.becareful.becarefulserver.global.exception.ErrorMessage.ELDERLY_NOT_EXISTS;
+import static com.becareful.becarefulserver.global.exception.ErrorMessage.MATCHING_NOT_EXISTS;
 import static com.becareful.becarefulserver.global.exception.ErrorMessage.RECRUITMENT_NOT_EXISTS;
 
 import org.springframework.stereotype.Service;
@@ -57,6 +58,20 @@ public class RecruitmentService {
 
         // TODO : recruit 매칭 적합도 및 태그 부여 판단
         return RecruitmentDetailResponse.from(recruitment, false, false, 98);
+    }
+
+    @Transactional
+    public void applyRecruitment(Long recruitmentId) {
+        Caregiver caregiver = authUtil.getLoggedInCaregiver();
+        Recruitment recruitment = recruitmentRepository.findById(recruitmentId)
+                .orElseThrow(() -> new RecruitmentException(RECRUITMENT_NOT_EXISTS));
+        WorkApplication workApplication = workApplicationRepository.findByCaregiver(caregiver)
+                .orElseThrow(() -> new RecruitmentException(CAREGIVER_WORK_APPLICATION_NOT_EXISTS));
+
+        Matching matching = matchingRepository.findByWorkApplicationAndRecruitment(workApplication, recruitment)
+                .orElseThrow(() -> new RecruitmentException(MATCHING_NOT_EXISTS));
+
+        matching.apply();
     }
 
     @Transactional

--- a/src/main/java/com/becareful/becarefulserver/global/exception/ErrorMessage.java
+++ b/src/main/java/com/becareful/becarefulserver/global/exception/ErrorMessage.java
@@ -29,4 +29,6 @@ public class ErrorMessage {
 
     public static final String RECRUITMENT_NOT_EXISTS = "매칭 공고가 존재하지 않습니다.";
     public static final String MATCHING_NOT_EXISTS = "매칭 또는 지원 정보가 존재하지 않습니다.";
+    public static final String MATCHING_CANNOT_APPLY = "미지원 공고에만 지원할 수 있습니다.";
+    public static final String MATCHING_CANNOT_REJECT = "미지원 공고만 거절할 수 있습니다.";
 }

--- a/src/main/java/com/becareful/becarefulserver/global/exception/ErrorMessage.java
+++ b/src/main/java/com/becareful/becarefulserver/global/exception/ErrorMessage.java
@@ -28,4 +28,5 @@ public class ErrorMessage {
     public static final String ELDERLY_NOT_EXISTS = "존재하지 않는 어르신입니다.";
 
     public static final String RECRUITMENT_NOT_EXISTS = "매칭 공고가 존재하지 않습니다.";
+    public static final String MATCHING_NOT_EXISTS = "매칭 또는 지원 정보가 존재하지 않습니다.";
 }


### PR DESCRIPTION
- 일자리 신청서가 없으면 일자리 공고 리스트 조회시 null 응답
- 매칭된 일자리 중 '미지원' 상태인 것만 조회되도록 처리 (지원, 합격, 거절, 불합격은 안 뜸)

close #19 
close #69 